### PR TITLE
Add codefences examples to Riot

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,22 @@ int main ()
 
 ### Riot
 
-```
+````
 This is an example of `inline code`
 
     Four spaces denote a code block
-    No syntax highlighting
+    
 ```
+Alternatively you can surround the code block with triple backticks
+```
+
+```rust
+fn main() {
+    println!("It supports syntax highlighting, too!");
+    // However it only highlights the code in Riot-Web.
+}
+```
+````
 
 ### Slack
 


### PR DESCRIPTION
Riot supports codefences as well.  Syntax highlighting seems to be only available on Riot-Web, however.  (I could not test with Riot/Android, as I do not own any Android device...)

obligatorisches "Bildnis sonst ward ihm kein Glaube geschenkt":

![image](https://user-images.githubusercontent.com/1809170/65982627-0f94d300-e47c-11e9-9429-32fd2e055a88.png)
